### PR TITLE
Add start menu cards with hover/click

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,78 +58,78 @@
       <input id="input" type="text" placeholder="Gebe die Farbe ein..." style="display: none;" />
     </div>
 
-<div id="Eingang">
+  <div id="Eingang">
   <div id="platzhalterZwei"></div>
-  <div class="intro-wrapper" style="display: static;"> <br><br>
-    <div class="intro-title">Willkommen zum Farb-Reaktionsspiel!</div> <br><br> <br> <br>
+  <div class="intro-wrapper" style="display: static;">
+    <div class="intro-title">Willkommen zum Farb-Reaktionsspiel!</div>
+    <div id="startCards">
 
-    <div class="intro-highlight">
-      Was passiert in deinem Körper, wenn du reagierst?
-    </div><br>
+      <div class="aspect-card">
+        <div class="aspect-header">Wissenswertes</div>
+        <div class="aspect-content">
+          <div class="intro-highlight">Was passiert in deinem Körper, wenn du reagierst?</div>
+          <div class="intro-text">
+            Deine Augen (Rezeptoren) erkennen Farben und senden die Info über <strong>afferente Nerven</strong> ans Gehirn.
+            Dort wird entschieden, was zu tun ist. Dann geht das Signal über <strong>efferente Bahnen</strong> zurück zu deinen Fingern – du tippst!
+            Das Gehirn überprüft über <strong>Reafferenzen</strong>, ob alles wie geplant ausgeführt wurde.
+          </div>
+          <div class="intro-subtle">Dieses Zusammenspiel von Wahrnehmung und Handlung nennt man <strong>Sensomotorik</strong>.</div>
+        </div>
+      </div>
 
-    <div class="intro-text">
-      Deine Augen (Rezeptoren) erkennen Farben und senden die Info über <strong>afferente Nerven</strong> ans Gehirn.
-      Dort wird entschieden, was zu tun ist. Dann geht das Signal über <strong>efferente Bahnen</strong> zurück zu deinen Fingern – du tippst!
-      Das Gehirn überprüft über <strong>Reafferenzen</strong>, ob alles wie geplant ausgeführt wurde.
-    </div><br> <br> 
+      <div class="aspect-card">
+        <div class="aspect-header">Über das Spiel</div>
+        <div class="aspect-content">
+          <div class="intro-highlight">Wie funktioniert das Spiel?</div>
+          <div class="intro-list">
+            <ul>
+              <li>Eine Farbe erscheint</li>
+              <li>Du tippst blitzschnell den Namen ein</li>
+              <li>Du wirst mit jeder Runde schneller</li>
+            </ul>
+          </div>
+          <div class="intro-info">
+            <ul>
+              <strong>Am Anfang gibst du an, wie viele Farben du in 1 Minute erkennst. Am Ende zeigen wir dir:</strong>
+              <li>Deine wahre Leistung</li>
+              <li>Deine Reaktionszeit auf unbekannte Reize</li>
+              <li>Deine Reaktionszeit auf bekannte Reize</li>
+              <li>Die Geschwindigkeit deiner Rythmisierung</li>
+              <li>Wie gut du dich selbst einschätzen kannst</li>
+              <li>Wie gut deine Zeitwahrnehmung ist</li>
+              <li>Wie gut deine Aufmerksamkeitsspanne ist</li>
+            </ul>
+          </div>
+        </div>
+      </div>
 
-    <div class="intro-subtle">
-      Dieses Zusammenspiel von Wahrnehmung und Handlung nennt man <strong>Sensomotorik</strong>.
-    </div> <br> <br> <br>
+      <div class="aspect-card">
+        <div class="aspect-header">Spielhinweise</div>
+        <div class="aspect-content">
+          <div class="intro-highlight">Wie schnell ist dein Gehirn wirklich?</div>
+          <div class="intro-text">
+            Wenn du im Spiel eine Farbe siehst und darauf reagierst,
+            <em> passiert blitzschnell</em>
+            eine ganze Menge in deinem Körper
+            <em>– und du merkst es kaum!</em>
+            <br><br>
+            1. Reiz wahrnehmen (ca. 50–100 ms) <br>
+            Deine Augen erkennen die Farbe. Die Sinneszellen in der Netzhaut senden die Info über afferente Nervenbahnen ins Gehirn. <br><br>
+            2. Farbe verarbeiten & erkennen (ca. 100–150 ms) <br>
+            Dein Gehirn sagt: „Ah – das ist <span style="color: red; text-shadow: 0 0 10px #ffd0d0;">rot</span>!“ und gleicht es mit deinem Gedächtnis ab. <br><br>
+            3. Entscheidung treffen (ca. 70–100 ms) <br>
+            Du wählst blitzschnell den passenden Handlungsplan: „Ich schreibe <span style="color: red; text-shadow: 0 0 10px #ffd0d0;">rot</span>!“ <br><br>
+            4. Aktion ausführen (ca. 100–150 ms) <br>
+            <strong>Dein Befehl reist über efferente Bahnen zu deinen Fingern – du tippst los!</strong>
+            <br><br>
+            <em>Für all das braucht der Mensch im Durchschnitt ~ 1.000ms - Teste Dich! <strong>Wie gut bist Du?</strong></em>
+          </div>
+        </div>
+      </div>
 
-
-      <div class="intro-highlight">
-      Wie funktioniert das Spiel?
     </div>
-
-    <div class="intro-list"> <br>
-      <ul>
-        <li>Eine Farbe erscheint</li><br>
-        <li>Du tippst blitzschnell den Namen ein</li> <br>
-        <li>Du wirst mit jeder Runde schneller</li><br>
-      </ul>
-    </div> <br><br>
-
-      <div class="intro-info">
-      <ul>
-        <strong>Am Anfang gibst du an, wie viele Farben du in 1 Minute erkennst. Am Ende zeigen wir dir:</strong> <br><br>
-        <li>Deine wahre Leistung</li> <br>
-        <li>Deine Reaktionszeit auf unbekannte Reize</li> <br>
-        <li>Deine Reaktionszeit auf bekannte Reize</li><br>
-        <li>Die Geschwindigkeit deiner Rythmisierung</li><br>
-        <li>Wie gut du dich selbst einschätzen kannst</li><br>
-        <li>Wie gut deine Zeitwahrnehmung ist</li><br>
-        <li>Wie gut deine Aufmerksamkeitsspanne ist</li><br>
-      </ul>
-    </div>
-
-    <div class="intro-text"> <br><br>
-    <div class="intro-highlight">Wie schnell ist dein Gehirn wirklich?</div><br><br>
-    Wenn du im Spiel eine Farbe siehst und darauf reagierst, 
-    <em> passiert blitzschnell</em>
-      eine ganze Menge in deinem Körper 
-      <em>– und du merkst es kaum!</em> <br> <br>
-
-  1. Reiz wahrnehmen (ca. 50–100 ms) <br> 
-  Deine Augen erkennen die Farbe. Die Sinneszellen in der Netzhaut senden die Info über afferente Nervenbahnen ins Gehirn. <br> <br>
-
-  2. Farbe verarbeiten & erkennen (ca. 100–150 ms) <br>
-  Dein Gehirn sagt: „Ah – das ist <span style="color: red; text-shadow: 0 0 10px #ffd0d0;">rot</span>!“ und gleicht es mit deinem Gedächtnis ab. <br> <br>
-
-  3. Entscheidung treffen (ca. 70–100 ms) <br>
-  Du wählst blitzschnell den passenden Handlungsplan: „Ich schreibe <span style="color: red; text-shadow: 0 0 10px #ffd0d0;">rot</span>!“ <br> <br>
-
-  4. Aktion ausführen (ca. 100–150 ms) <br>
-  <strong>Dein Befehl reist über efferente Bahnen zu deinen Fingern – du tippst los!</strong>
-  <br> <br>
-
-  <em>
-  Für all das braucht der Mensch im Durchschnitt ~ 1.000ms - Teste Dich! <strong> Wie gut bist Du ?</strong>
-  </em>
-    </div> <br>
-
     <div class="intro-call">Bereit? Dann leg los und finde heraus, wie schnell dein Kopf wirklich ist!</div>
-  </div> <br> <br> <br>
+  </div>
   <div id="platzhalter"></div>
 
   <div class="containerNachClick">

--- a/js-neu.css
+++ b/js-neu.css
@@ -869,3 +869,54 @@ transition: 0.3s ease;
 .rang-highlight {
   animation: pulse-card 1s ease-in-out infinite;
 }
+
+/* === Startmenü Karten === */
+#startCards {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+  margin-top: 20px;
+}
+
+.aspect-card {
+  width: 90%;
+  max-width: 600px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 2px solid rgb(0, 225, 255);
+  border-radius: 15px;
+  overflow: hidden;
+  color: white;
+  cursor: pointer;
+  transition: max-height 0.6s ease;
+  max-height: 50px;
+  padding: 10px;
+}
+
+.aspect-card.hovering,
+.aspect-card.open {
+  max-height: 1000px;
+}
+
+.aspect-header {
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 10px;
+  color: rgb(0, 225, 255);
+}
+
+.aspect-content {
+  display: none;
+}
+
+.aspect-card.hovering .aspect-content,
+.aspect-card.open .aspect-content {
+  display: block;
+  animation: scroll-open 0.5s ease;
+}
+
+@keyframes scroll-open {
+  from { transform: translateY(-20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}

--- a/js-neu.js
+++ b/js-neu.js
@@ -313,6 +313,28 @@ const overlay = document.getElementById("letsTestOverlay");
 const timeOver = document.getElementById("timeOver");
 const timeOverContainer=document.getElementById("timeOverContainer");
 
+// Karten im Startmenü
+const startCards = document.querySelectorAll('.aspect-card');
+startCards.forEach(card => {
+  const header = card.querySelector('.aspect-header');
+  let fixedOpen = false;
+
+  header.addEventListener('click', () => {
+    fixedOpen = !fixedOpen;
+    card.classList.toggle('open', fixedOpen);
+  });
+
+  card.addEventListener('mouseenter', () => {
+    card.classList.add('hovering');
+  });
+
+  card.addEventListener('mouseleave', () => {
+    if (!fixedOpen) {
+      card.classList.remove('hovering');
+    }
+  });
+});
+
 
 let zustand = 0;
 let korrektAnzahl = 0;


### PR DESCRIPTION
## Summary
- restructure intro section into expandable cards
- style cards and add dropdown animation
- add JS logic to open cards on hover or click

## Testing
- `node --check js-neu.js`

------
https://chatgpt.com/codex/tasks/task_e_68441579cd6c83288807cc760c6d7170