### PR TITLE
Fix syntax errors, tidy CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
 </div>
 
     <div id="platzmacher"></div>
-  <div id=placemaker></div> 
 
 
     <div class="anzeige-wrapper">

--- a/js-neu.css
+++ b/js-neu.css
@@ -254,7 +254,7 @@ display: none;
   border-radius: 5px;
   height: 30px;
   width: 200px;
-  font-family: 'Sergio-UI', sans-serif;
+  font-family: 'Segoe UI', sans-serif;
   font-size: 14px;
   padding: 5px;
   transition: 0.3s ease;
@@ -276,7 +276,7 @@ display: none;
   width: 90px;
   border-radius: 20px;
   padding: 15px;
-  font-family: 'Sergio-UI', sans-serif;
+  font-family: 'Segoe UI', sans-serif;
   font-weight: bold;
   font-size: 13px;
   display: flex;
@@ -376,7 +376,7 @@ transition: 0.3s ease;
   z-index: 10;
   /* dein bisheriges Styling */
   display: block;
-  font-family: 'Sergio-UI', sans-serif;
+  font-family: 'Segoe UI', sans-serif;
   border-radius: 30px;
   width: 150px;
   margin: 15% auto 0;
@@ -542,20 +542,6 @@ transition: 0.3s ease;
   }
 }
 
-#placemaker {
-  display: block;
-}
-
-#placemaker.sichtbar {
-  bottom: 100%;
-  left: 50%;
-  right:50%;
-  transform: translate(-50%, -50%);
-  position: relative;
-  height: 2vh;
-  width: 20vh;
-  background-color: transparent;
-}
 
 #platzmacher.sichtbar {
   bottom: 100%;

--- a/js-neu.js
+++ b/js-neu.js
@@ -336,7 +336,6 @@ startCards.forEach(card => {
     card.classList.remove('hovering');
     if (!fixedOpen) {
       card.classList.remove('open');
-    if (!fixedOpen) {
       card.classList.remove('hovering');
     }
   });


### PR DESCRIPTION
## Summary
- fix syntax error in start menu card handler
- clean up unused placeholder div and CSS
- correct font family typos

## Testing
- `node --check js-neu.js`
- `npx stylelint js-neu.css` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_68441ed65a208328acaf147c778a9d4e