### PR TITLE
Fix dropdown content visibility

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -1047,7 +1047,6 @@ transition: 0.3s ease;
   transform: translateY(-20px);
   transition: opacity 0.4s ease, transform 0.4s ease;
   pointer-events: none;
-  display: none;
 }
 
 .aspect-card.hovering .aspect-content,


### PR DESCRIPTION
## Summary
- ensure dropdown card content is visible again by removing `display: none` from `.aspect-content`

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6844272edaec8328940b935a47097882