### PR TITLE
Make welcome heading responsive

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -668,7 +668,7 @@ transition: 0.3s ease;
   font-family: "StreamerSlant", sans-serif;
   color: rgb(0, 225, 255);
   letter-spacing: 12px;
-  font-size: 60px;
+  font-size: clamp(32px, 8vw, 60px);
   text-shadow: #00e1ff 0px 0px 15px;
 
 }


### PR DESCRIPTION
## Summary
- ensure the `#welcome` heading scales on different devices using `clamp`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7805f488328bf06c62917214236