### PR TITLE
Increase height of aspect cards

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -954,7 +954,7 @@ transition: 0.3s ease;
   color: #00e1ff;
   cursor: pointer;
   transition: max-height 0.6s ease, box-shadow 0.3s ease, background-color 0.3s ease, color 0.3s ease;
-  max-height: 60px;
+  max-height: 90px;
   padding: 15px;
   box-sizing: border-box;
   box-shadow: 0 0 15px #00e1ff;
@@ -1124,12 +1124,12 @@ transition: 0.3s ease;
   color: #00e1ff;
   cursor: pointer;
   transition: max-height 0.6s ease, box-shadow 0.3s ease, background-color 0.3s ease, color 0.3s ease;
-  max-height: 60px;
+  max-height: 90px;
   padding: 15px;
   box-sizing: border-box;
   box-shadow: 0 0 15px #00e1ff;
   transition: max-height 0.6s ease;
-  max-height: 50px;
+  max-height: 90px;
   padding: 10px;
 }
 


### PR DESCRIPTION
## Summary
- bump the default height of `.aspect-card` to give more space before opening or hovering

## Testing
- `grep -n "max-height:" -n js-neu.css`

------
https://chatgpt.com/codex/tasks/task_e_6845d78e4abc8328b21a3172059e8d4e