### PR TITLE
Add shader background on login

### DIFF
--- a/background-animation.js
+++ b/background-animation.js
@@ -1,0 +1,49 @@
+const canvas = document.getElementById("shaderCanvas");
+const gl = canvas.getContext("webgl");
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+const fragShaderText = document.getElementById("fragShader").textContent;
+
+const vertexShaderSource = `
+  attribute vec2 position;
+  void main() {
+    gl_Position = vec4(position, 0.0, 1.0);
+  }
+`;
+
+function createShader(type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  return shader;
+}
+
+const vs = createShader(gl.VERTEX_SHADER, vertexShaderSource);
+const fs = createShader(gl.FRAGMENT_SHADER, fragShaderText);
+const program = gl.createProgram();
+gl.attachShader(program, vs);
+gl.attachShader(program, fs);
+gl.linkProgram(program);
+gl.useProgram(program);
+
+const vertices = new Float32Array([
+  -1, -1,  1, -1,  -1, 1,
+  -1, 1,   1, -1,   1, 1
+]);
+
+const buffer = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+const loc = gl.getAttribLocation(program, "position");
+gl.enableVertexAttribArray(loc);
+gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+function render(time) {
+  gl.viewport(0, 0, canvas.width, canvas.height);
+  gl.uniform1f(gl.getUniformLocation(program, "iTime"), time * 0.001);
+  gl.uniform2f(gl.getUniformLocation(program, "iResolution"), canvas.width, canvas.height);
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+  requestAnimationFrame(render);
+}
+render();

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bodymovin/5.9.6/lottie.min.js"></script>
 </head>
 <body class="body" style="position: relative;">
+<canvas id="shaderCanvas"></canvas>
    
 <div id="letsTestOverlay" class="overlay" style="display: none;">
   <div class="overlay-content animate-popup">
@@ -188,6 +189,27 @@
   </div>
 
 </div>
+<script type="x-shader/x-fragment" id="fragShader">
+  precision mediump float;
+  uniform float iTime;
+  uniform vec2 iResolution;
+  void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    uv = uv * 2.0 - 1.0;
+    uv.x *= iResolution.x / iResolution.y;
+    float t = iTime * 0.2;
+    float r = length(uv);
+    float a = atan(uv.y, uv.x);
+    float f = cos(10.0 * (r + t)) * 0.5 + 0.5;
+    float glow = 0.005 / abs(f - 0.5);
+    vec3 col = mix(vec3(0.165), vec3(0.0, 1.0, 1.0), clamp(glow, 0.0, 1.0));
+    fragColor = vec4(col, 1.0);
+  }
+  void main() {
+    mainImage(gl_FragColor, gl_FragCoord.xy);
+  }
+</script>
+<script src="background-animation.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="js-neu.js"></script>
 </body>

--- a/js-neu.css
+++ b/js-neu.css
@@ -1208,3 +1208,14 @@ transition: 0.3s ease;
   from { box-shadow: 0 0 30px rgb(0, 225, 255); }
   to   { box-shadow: 0 0 20px rgb(0, 225, 255); }
 }
+
+#shaderCanvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  display: block;
+}
+

--- a/js-neu.js
+++ b/js-neu.js
@@ -214,6 +214,7 @@ document.getElementById("startWeiterBtn").addEventListener("click", () => {
       soundSignup.play();
       document.getElementById("startbildschirm").style.display = "none";
       document.getElementById("mainContent").style.display = "block";
+      document.getElementById("shaderCanvas").style.display = "none";
       startErfolgt = true;
     });
 });


### PR DESCRIPTION
## Summary
- add WebGL background canvas
- integrate shader script and loader
- hide animation after user signs in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846a9fb7594832899e413f9f2f61c55