### PR TITLE
Add next round button

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,7 @@
       <div class="auswertung-item" id="box-reaktion-bekannt"></div>
       <canvas class="auswertung-item" id="reaktionsChart"></canvas>
     </div>
+    <button id="nextRoundBtn" style="display:none;">Next Round</button>
   </div>
 
 </div>

--- a/js-neu.css
+++ b/js-neu.css
@@ -107,6 +107,32 @@
   box-shadow: 0 0 25px #00e1ff, 0 0 50px #00e1ff;
 }
 
+#nextRoundBtn {
+  position: relative;
+  display: none;
+  margin: 40px auto;
+  padding: 15px 30px;
+  width: 180px;
+  height: 55px;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 14px;
+  font-weight: bold;
+  color: #00e1ff;
+  background-color: #111;
+  border: 2px solid #00e1ff;
+  border-radius: 25px;
+  box-shadow: 0 0 15px #00e1ff;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.3s ease;
+}
+
+#nextRoundBtn:hover {
+  background-color: #00e1ff;
+  color: #000;
+  box-shadow: 0 0 25px #00e1ff, 0 0 50px #00e1ff;
+}
+
 #platzhalterZwei {
   width: 100vw;
   height: 1vh;

--- a/js-neu.js
+++ b/js-neu.js
@@ -362,6 +362,7 @@ const eingabeInfos = document.querySelectorAll(".EingabeInfosContainer");
 const overlay = document.getElementById("letsTestOverlay");
 const timeOver = document.getElementById("timeOver");
 const timeOverContainer=document.getElementById("timeOverContainer");
+const nextRoundBtn = document.getElementById("nextRoundBtn");
 
 // Karten im Startmenü
 document.addEventListener('DOMContentLoaded', () => {
@@ -822,6 +823,11 @@ datenSpeichern()
   document.querySelector(".auswertung").style.height = "auto";
   window.addEventListener("resize", passeAuswertungBoxAn);
   passeAuswertungBoxAn();
+
+  const totalDelay = items.length * 900 + 1200;
+  setTimeout(() => {
+    nextRoundBtn.style.display = "block";
+  }, totalDelay);
 });
 
 
@@ -887,3 +893,44 @@ function starteTimer() {
     }
   }, 10);
 }
+
+nextRoundBtn.addEventListener("click", () => {
+  const box = document.querySelector(".auswertung-box");
+  box.classList.remove("sichtbar");
+  document.querySelectorAll(".auswertung-item").forEach(item => {
+    item.classList.remove("sichtbar", "animate");
+  });
+  document.getElementById("ranglisteContainer").innerHTML = "";
+  document.getElementById("box-reaktion-beste").textContent = "";
+  document.getElementById("box-einschaetzung").textContent = "";
+  document.getElementById("box-punkte").textContent = "";
+  document.getElementById("box-reaktion-unbekannt").textContent = "";
+  document.getElementById("box-reaktion-bekannt").textContent = "";
+  document.getElementById("reaktionsChart").style.display = "none";
+  nextRoundBtn.style.display = "none";
+
+  [introWrapper, introTitle, introSubtle, introList, introInfo, introCall].forEach(el => el.classList.remove("unsichtbar"));
+  introHighlights.forEach(el => el.classList.remove("unsichtbar"));
+  introTexts.forEach(el => el.classList.remove("unsichtbar"));
+  eingabeInfos.forEach(el => el.classList.add("sichtbar"));
+
+  document.getElementById("wuerfelAnimation").style.display = "flex";
+  document.getElementById("platzmacher").classList.remove("sichtbar");
+  button.style.display = "block";
+
+  spielGestartet = false;
+  ersterClickGetan = false;
+  timerGestartet = false;
+  countedNum = false;
+  counted = false;
+  zustand = 0;
+  korrektAnzahl = 0;
+  reaktionszeiten = [];
+  anzahl = null;
+  spielStartBereit = false;
+
+  sekTens.textContent = 0;
+  sek.textContent = 0;
+  msHundreds.textContent = 0;
+  msTens.textContent = 0;
+});


### PR DESCRIPTION
## Summary
- add button after result list to start a new round
- style `nextRoundBtn` like the main game button
- show the button once results are animated
- reset state on click so the player can play again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846bbc0b418832890d2d5746d517248