### PR TITLE
Fix next round button placement

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -108,9 +108,12 @@
 }
 
 #nextRoundBtn {
-  position: relative;
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
   display: none;
-  margin: 40px auto;
   padding: 15px 30px;
   width: 180px;
   height: 55px;
@@ -501,6 +504,11 @@ transition: 0.3s ease;
   font-weight: bold;
   transition: 0.3s ease;
   margin: 10px;
+}
+
+.auswertung {
+  position: relative;
+  min-height: 100vh;
 }
 
 .auswertung-box, .auswertung-item, .EingabeInfosContainer {


### PR DESCRIPTION
## Summary
- position the evaluation container relative to keep space for the button
- move the next round button to the bottom center of the evaluation container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846bed5b048832891cfbcec0edccb98