### PR TITLE
Fix result spacing and login hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
       <div class="container">
       <button id="gameBtn">Click me</button>
     </div>
-  <div id="wuerfelAnimation" style="width: 90%; height: 90%; margin: 20px auto; margin-top: 150px;"></div>
+  <div id="wuerfelAnimation"></div>
 </div>
 
     <div id="textAdj">

--- a/js-neu.css
+++ b/js-neu.css
@@ -125,7 +125,7 @@
   cursor: pointer;
   text-align: center;
   transition: all 0.3s ease;
-  margin-top: 650px;
+  margin-top: 30px;
 }
 
 #nextRoundBtn:hover {
@@ -817,6 +817,11 @@ transition: 0.3s ease;
 .login-container * {
   z-index: 2;
   position: relative;
+  transition: transform 0.2s ease;
+}
+
+.login-container > *:hover {
+  transform: translateY(-5px);
 }
 
 @keyframes rotBGimg {
@@ -866,7 +871,11 @@ transition: 0.3s ease;
   height: auto;
   display: flex;
   justify-content: center;
-  margin: 0 auto;
+  margin: 150px auto 0;
+}
+
+#wuerfelAnimation.result {
+  margin-top: 30px;
 }
 
 #wuerfelAnimation.unsichtbar {
@@ -1298,5 +1307,15 @@ transition: 0.3s ease;
   height: 100vh;
   z-index: -1;
   display: block;
+}
+
+
+@media (max-width: 600px) {
+  #wuerfelAnimation.result {
+    margin-top: 20px;
+  }
+  #nextRoundBtn {
+    margin-top: 20px;
+  }
 }
 

--- a/js-neu.js
+++ b/js-neu.js
@@ -658,10 +658,12 @@ starteCountdown(() => {
 
     buttonSec.classList.remove("sichtbar");
     anzeigeWrapper.classList.remove("sichtbar");
-    document.getElementById("wuerfelAnimation").style.display = "flex";
-    document.getElementById("wuerfelAnimation").style.position = "relative";
-    document.getElementById("wuerfelAnimation").style.top = "50vh";
-    document.getElementById("wuerfelAnimation").style.marginTop = "600px";
+    const wuerfel = document.getElementById("wuerfelAnimation");
+    wuerfel.style.display = "flex";
+    wuerfel.classList.add("result");
+    wuerfel.style.position = "";
+    wuerfel.style.top = "";
+    wuerfel.style.marginTop = "";
 
 
     document.getElementById("platzmacher").classList.add("sichtbar");
@@ -932,10 +934,14 @@ nextRoundBtn.addEventListener("click", () => {
   introHighlights.forEach(el => el.classList.remove("unsichtbar"));
   introTexts.forEach(el => el.classList.remove("unsichtbar"));
   eingabeInfos.forEach(el => el.classList.add("sichtbar"));
-  window.scrollTo({ top: 600, behavior: "smooth" });
+  window.scrollTo({ top: 0, behavior: "smooth" });
 
-
-  document.getElementById("wuerfelAnimation").style.display = "flex";
+  const wuerfel = document.getElementById("wuerfelAnimation");
+  wuerfel.style.display = "flex";
+  wuerfel.classList.remove("result");
+  wuerfel.style.position = "";
+  wuerfel.style.top = "";
+  wuerfel.style.marginTop = "";
   document.getElementById("platzmacher").classList.remove("sichtbar");
   button.style.display = "block";
 


### PR DESCRIPTION
## Summary
- reduce margin for dice animation and next round button
- keep dice animation size after each round
- add responsive spacing and hover effects in login
- remove inline style for dice container and reset scroll on next round

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846db60a164832895d7e5d1ff8c1c1f