### PR TITLE
Fix cube size, mobile placement, and scroll

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -867,8 +867,8 @@ transition: 0.3s ease;
 
 
 #wuerfelAnimation {
-  width: 90%;
-  max-width: 400px;
+  width: 60%;
+  max-width: 250px;
   height: auto;
   display: flex;
   justify-content: center;
@@ -1313,7 +1313,7 @@ transition: 0.3s ease;
 
 @media (max-width: 600px) {
   #wuerfelAnimation.result {
-    margin-top: 20px;
+    margin-top: 550px;
   }
   #nextRoundBtn {
     margin-top: 20px;

--- a/js-neu.js
+++ b/js-neu.js
@@ -935,6 +935,8 @@ nextRoundBtn.addEventListener("click", () => {
   introTexts.forEach(el => el.classList.remove("unsichtbar"));
   eingabeInfos.forEach(el => el.classList.add("sichtbar"));
   window.scrollTo({ top: 0, behavior: "smooth" });
+  document.body.scrollTop = 0;
+  document.documentElement.scrollTop = 0;
 
   const wuerfel = document.getElementById("wuerfelAnimation");
   wuerfel.style.display = "flex";


### PR DESCRIPTION
## Summary
- resize cube animation container
- ensure cube appears below results on mobile
- force scroll to top when starting next round

## Testing
- `git status --short`
- `git show -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6846e725f43883289347b56e4e090789