### PR TITLE
Adjust cube position when results appear

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -876,7 +876,7 @@ transition: 0.3s ease;
 }
 
 #wuerfelAnimation.result {
-  margin-top: 950px;
+  margin-top: 1050px;
 }
 
 #wuerfelAnimation.unsichtbar {
@@ -1313,7 +1313,7 @@ transition: 0.3s ease;
 
 @media (max-width: 600px) {
   #wuerfelAnimation.result {
-    margin-top: 550px;
+    margin-top: 650px;
   }
   #nextRoundBtn {
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- move the results cube 100px lower on regular and small screens

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb496c6083288f76432dec9e4449