### PR TITLE
Fix smartphone margin for dice animation

### DIFF
--- a/js-neu.css
+++ b/js-neu.css
@@ -1323,7 +1323,7 @@ transition: 0.3s ease;
     max-width: none;
   }
   #wuerfelAnimation.result {
-    margin-top: 650px;
+    margin-top: 1550px;
   }
   #nextRoundBtn {
     margin-top: 20px;


### PR DESCRIPTION
## Summary
- bump `wuerfelAnimation` margin for small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847fd3772788328860284a1ac54e294