### PR TITLE
Implement closing animation after game ends

### DIFF
--- a/js-neu-en.js
+++ b/js-neu-en.js
@@ -647,6 +647,8 @@ starteCountdown(() => {
 
 
   setTimeout(() => {
+    const mainContent = document.getElementById("mainContent");
+    mainContent.classList.add("close-open");
     punkteZeiger.classList.remove("sichtbar");
     input.style.display = "none";
     karte.classList.remove("sichtbar");
@@ -858,6 +860,9 @@ datenSpeichern()
     nextRoundBtn.style.display = "block";
   }, totalDelay);
 });
+    setTimeout(() => {
+      mainContent.classList.remove("close-open");
+    }, 1000);
 
 
   }, 64000);

--- a/js-neu.css
+++ b/js-neu.css
@@ -1569,3 +1569,22 @@ transition: 0.3s ease;
     margin-top: 20px;
   }
 }
+
+@keyframes closeOpen {
+  0% {
+    clip-path: circle(500% at center);
+    opacity: 1;
+  }
+  50% {
+    clip-path: circle(0% at center);
+    opacity: 0;
+  }
+  100% {
+    clip-path: circle(500% at center);
+    opacity: 1;
+  }
+}
+.close-open {
+  animation: closeOpen 1s forwards;
+  overflow: hidden;
+}

--- a/js-neu.js
+++ b/js-neu.js
@@ -671,16 +671,12 @@ starteCountdown(() => {
 
 
   setTimeout(() => {
-document.querySelectorAll(".gamecontent").forEach(element => {
-    element.style.transition = "opacity 0.5s ease";
-});      
-document.querySelectorAll(".gamecontent").forEach(element => {
-    element.style.opacity = "0";
-});      
-      timeOverContainer.style.display = "flex";
-      timeOver.style.display = "block";
-      timeOverContainer.style.opacity = "1";
-      timeOver.style.opacity = "1";
+    const mainContent = document.getElementById("mainContent");
+    mainContent.classList.add("close-open");
+    timeOverContainer.style.display = "flex";
+    timeOver.style.display = "block";
+    timeOverContainer.style.opacity = "1";
+    timeOver.style.opacity = "1";
 
 setTimeout (() => {
 document.querySelectorAll(".auswertung").forEach(element => {
@@ -898,6 +894,10 @@ datenSpeichern()
     nextRoundBtn.style.display = "block";
   }, totalDelay);
 });
+
+    setTimeout(() => {
+      mainContent.classList.remove("close-open");
+    }, 1000);
 
   }, 500);
   }, 64000);


### PR DESCRIPTION
## Summary
- add `closeOpen` keyframe animation and helper class
- trigger animation at timeout in German and English scripts
- remove animation class after it completes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ab7d69e8c8328bc276288c3d8cd32