### PR TITLE
Implement text color change on second card click

### DIFF
--- a/js-neu-en.js
+++ b/js-neu-en.js
@@ -256,19 +256,27 @@ document.body.style.opacity = "1";
     });
 });
 
-let clickedDropDown = false;
+let aspectClickCount = 0;
 
-document.querySelector('.aspect-card').addEventListener('click', () => {
-        const elements = document.querySelectorAll('.intro-text, .intro-subtle, #EingabeInfosTitle, .intro-list, #EingabeInfosText, ul.sichtbar, .intro-info ul, .intro-highlight');
+document.querySelectorAll('.aspect-card').forEach(card => {
+  card.addEventListener('click', () => {
+    const elements = document.querySelectorAll(
+      '.intro-text, .intro-subtle, #EingabeInfosTitle, .intro-list, #EingabeInfosText, ul.sichtbar, .intro-info ul, .intro-highlight'
+    );
 
-        if (!clickedDropDown) {
-            elements.forEach(el => el.classList.add('hover'));
-            clickedDropDown = true;
-        } else if (!fixedOpen){
-            elements.forEach(el => el.classList.remove('hover'));
-            clickedDropDown = false;
-        }
-    });
+    aspectClickCount++;
+
+    if (aspectClickCount === 1) {
+      elements.forEach(el => el.classList.add('hover'));
+    } else if (aspectClickCount === 2) {
+      elements.forEach(el => {
+        el.classList.remove('hover');
+        el.style.setProperty('color', 'black', 'important');
+      });
+      aspectClickCount = 0;
+    }
+  });
+});
 
 
 // Beim Klicken des Spielstart-Buttons:

--- a/js-neu.js
+++ b/js-neu.js
@@ -256,19 +256,27 @@ document.body.style.opacity = "1";
     });
 });
 
-let clickedDropDown = false;
+let aspectClickCount = 0;
 
-document.querySelector('.aspect-card').addEventListener('click', () => {
-        const elements = document.querySelectorAll('.intro-text, .intro-subtle, #EingabeInfosTitle, .intro-list, #EingabeInfosText, ul.sichtbar, .intro-info ul, .intro-highlight');
+document.querySelectorAll('.aspect-card').forEach(card => {
+  card.addEventListener('click', () => {
+    const elements = document.querySelectorAll(
+      '.intro-text, .intro-subtle, #EingabeInfosTitle, .intro-list, #EingabeInfosText, ul.sichtbar, .intro-info ul, .intro-highlight'
+    );
 
-        if (!clickedDropDown) {
-            elements.forEach(el => el.classList.add('hover'));
-            clickedDropDown = true;
-        } else if (!fixedOpen){
-            elements.forEach(el => el.classList.remove('hover'));
-            clickedDropDown = false;
-        }
-    });
+    aspectClickCount++;
+
+    if (aspectClickCount === 1) {
+      elements.forEach(el => el.classList.add('hover'));
+    } else if (aspectClickCount === 2) {
+      elements.forEach(el => {
+        el.classList.remove('hover');
+        el.style.setProperty('color', 'black', 'important');
+      });
+      aspectClickCount = 0;
+    }
+  });
+});
 
 
 


### PR DESCRIPTION
## Summary
- modify logic to track clicks on all aspect cards
- on second click, force text color to black using `!important`
- apply same behavior to English version script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d99794e9483289643e84a164240c6