### PR TITLE
Ensure current player appears in rankings

### DIFF
--- a/js-neu-en.js
+++ b/js-neu-en.js
@@ -716,18 +716,13 @@ const items = document.querySelectorAll(".auswertung-item");
 datenSpeichern()
   .then(() => ladeAlleScores())
   .then(scores => {
-  const EPSILON = 0.01;
-
   const sortiert = scores
     .map(s => ({ ...s, besteReaktion: Number(s.besteReaktion) }))
     .filter(s => !isNaN(s.besteReaktion))
     .sort((a, b) => a.besteReaktion - b.besteReaktion)
     .map((s, i) => ({ ...s, rang: i + 1 }));
 
-  const currentBest = Number(besteReaktion.toFixed(2));
-  const aktuellerEintrag = sortiert.find(
-    s => s.userId === userId && Math.abs(s.besteReaktion - currentBest) < EPSILON
-  );
+  const aktuellerEintrag = sortiert.find(s => s.userId === userId);
 
   const top3 = sortiert.slice(0, 3);
 

--- a/js-neu.js
+++ b/js-neu.js
@@ -715,18 +715,13 @@ const items = document.querySelectorAll(".auswertung-item");
 datenSpeichern()
   .then(() => ladeAlleScores())
   .then(scores => {
-  const EPSILON = 0.01;
-
   const sortiert = scores
     .map(s => ({ ...s, besteReaktion: Number(s.besteReaktion) }))
     .filter(s => !isNaN(s.besteReaktion))
     .sort((a, b) => a.besteReaktion - b.besteReaktion)
     .map((s, i) => ({ ...s, rang: i + 1 }));
 
-  const currentBest = Number(besteReaktion.toFixed(2));
-  const aktuellerEintrag = sortiert.find(
-    s => s.userId === userId && Math.abs(s.besteReaktion - currentBest) < EPSILON
-  );
+  const aktuellerEintrag = sortiert.find(s => s.userId === userId);
 
   const top3 = sortiert.slice(0, 3);
 


### PR DESCRIPTION
## Summary
- show the score entry of the current player regardless of position
- remove time tolerance logic when picking the current player's score

## Testing
- `node --check js-neu.js`
- `node --check js-neu-en.js`


------
https://chatgpt.com/codex/tasks/task_e_6864da43f11483289d4c030d1e4aedff